### PR TITLE
Add support for z Stacks in VSI

### DIFF
--- a/src/slideio/drivers/vsi/vsislide.cpp
+++ b/src/slideio/drivers/vsi/vsislide.cpp
@@ -41,7 +41,7 @@ void VSISlide::init()
                 auto volume = etsFile->getVolume();
                 if (volume) {
                     const vsi::StackType stackType = volume->getType();
-                    if (stackType == vsi::StackType::DEFAULT_IMAGE) {
+                    if ((stackType == vsi::StackType::DEFAULT_IMAGE) || (stackType == vsi::StackType::EFI_STACK)){
                         m_Scenes.push_back(scene);
                     }
                     else {
@@ -53,8 +53,11 @@ void VSISlide::init()
                     for (int auxIndex = 0; auxIndex < auxImages; ++auxIndex) {
                         auto auxVolume = volume->getAuxVolume(auxIndex);
                         if (auxVolume) {
-                            auto auxScene = std::make_shared<VsiFileScene>(m_filePath, m_vsiFile, auxVolume->getIFD());
-                            scene->addAuxImage(auxVolume->getName(), auxScene);
+                            if (auxVolume->getIFD()>-1)
+                            {
+                             auto auxScene = std::make_shared<VsiFileScene>(m_filePath, m_vsiFile, auxVolume->getIFD());
+                             scene->addAuxImage(auxVolume->getName(), auxScene);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I also had a z stack image by the Olympus VS200 that I had a chance to test. I realized that it almost worked, but there were two little changes required:

- The EFI_STACK stack type was so far ignored.
- And my file here had an auxiliary image without a valid IFD tag, so it remained -1, causing an error when loading the file. I think that the additional if clause doesn't hurt anyhow :-)

I will try to get my hands on a tiny test sample to provide, so I could also enhance the tests in that regard.