### PR TITLE
use #prgama once in header files

### DIFF
--- a/src/slideio/converter/converter.hpp
+++ b/src/slideio/converter/converter.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_converter_HPP
-#define OPENCV_slideio_converter_HPP
+#pragma once
 
 #include "convertercallback.hpp"
 #include "slideio/converter/converter_def.hpp"
@@ -30,6 +29,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/converter/convertertools.hpp
+++ b/src/slideio/converter/convertertools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_convertertools_HPP
-#define OPENCV_slideio_convertertools_HPP
+#pragma once
 
 #include <vector>
 #include <opencv2/core/mat.hpp>
@@ -35,5 +34,3 @@ namespace slideio
         };
     }
 }
-
-#endif

--- a/src/slideio/converter/tiffconverter.hpp
+++ b/src/slideio/converter/tiffconverter.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 #include "slideio/converter/converter_def.hpp"
 #include "slideio/imagetools/tiffkeeper.hpp"
 #include "slideio/converter/converterparameters.hpp"

--- a/src/slideio/core/cvscene.hpp
+++ b/src/slideio/core/cvscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_scene_HPP
-#define OPENCV_slideio_scene_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include "slideio/base/resolution.hpp"
@@ -254,6 +253,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/core/cvslide.hpp
+++ b/src/slideio/core/cvslide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_slide_HPP
-#define OPENCV_slideio_slide_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -98,6 +97,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/core/cvsmallscene.hpp
+++ b/src/slideio/core/cvsmallscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_cvsmallscene_HPP
-#define OPENCV_slideio_cvsmallscene_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -60,5 +59,3 @@ namespace slideio
         DataType m_channelDataType;
     };
 };
-
-#endif

--- a/src/slideio/core/imagedriver.hpp
+++ b/src/slideio/core/imagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_imagedriver_HPP
-#define OPENCV_slideio_imagedriver_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include "slideio/core/cvslide.hpp"
@@ -21,5 +20,3 @@ namespace slideio
         virtual std::string getFileSpecs() const = 0;
     };
 }
-
-#endif

--- a/src/slideio/core/metadata.hpp
+++ b/src/slideio/core/metadata.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_metadata_HPP
-#define OPENCV_slideio_metadata_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include <cstdint>
@@ -121,6 +120,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/core/metadata_internal.hpp
+++ b/src/slideio/core/metadata_internal.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_metadata_internal_HPP
-#define OPENCV_slideio_metadata_internal_HPP
+#pragma once
 
 #include "slideio/core/metadata.hpp"
 #include "slideio/base/slideio_enums.hpp"
@@ -17,5 +16,3 @@ namespace slideio { namespace detail {
         const std::string& rawMetadata, MetadataFormat fmt);
 
 }}
-
-#endif

--- a/src/slideio/core/tools/color_tools.hpp
+++ b/src/slideio/core/tools/color_tools.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 //
 #include <array>
 #include <string>

--- a/src/slideio/core/tools/cvtools.hpp
+++ b/src/slideio/core/tools/cvtools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.org/license.html.
-#ifndef OPENCV_slideio_cvtools_HPP
-#define OPENCV_slideio_cvtools_HPP
+#pragma once
 
 #include <opencv2/core.hpp>
 #include "slideio/core/slideio_core_def.hpp"
@@ -54,5 +53,3 @@ namespace slideio
         }
     };
 }
-
-#endif

--- a/src/slideio/core/tools/tilecomposer.hpp
+++ b/src/slideio/core/tools/tilecomposer.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_tilecomposer_HPP
-#define OPENCV_slideio_tilecomposer_HPP
+#pragma once
 
 #include "slideio/core/slideio_core_def.hpp"
 #include <opencv2/core.hpp>
@@ -25,5 +24,3 @@ namespace slideio
             const cv::Rect& blockRect, const cv::Size& blockSize, cv::OutputArray output, void* userData = nullptr);
     };
 }
-
-#endif

--- a/src/slideio/core/tools/tools.hpp
+++ b/src/slideio/core/tools/tools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_tools_HPP
-#define OPENCV_slideio_tools_HPP
+#pragma once
 
 #if defined(WIN32)
 #elif __APPLE__
@@ -129,4 +128,3 @@ namespace slideio
                             int interpolation = cv::INTER_LINEAR);
     };
 }
-#endif

--- a/src/slideio/core/tools/wildmat.h
+++ b/src/slideio/core/tools/wildmat.h
@@ -1,1 +1,3 @@
+#pragma once
+
 int wildmat(char* text, char* p);

--- a/src/slideio/drivers/afi/afiimagedriver.hpp
+++ b/src/slideio/drivers/afi/afiimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_afiimagedriver_HPP
-#define OPENCV_slideio_afiimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/afi/afi_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -19,4 +18,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-#endif

--- a/src/slideio/drivers/afi/afislide.hpp
+++ b/src/slideio/drivers/afi/afislide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_afislide_HPP
-#define OPENCV_slideio_afislide_HPP
+#pragma once
 
 #include "slideio/drivers/afi/afi_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -39,6 +38,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/czi/cziimagedriver.hpp
+++ b/src/slideio/drivers/czi/cziimagedriver.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_cziimagedriver_HPP
-#define OPENCV_slideio_cziimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/czi/czi_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -32,6 +31,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/czi/cziscene.hpp
+++ b/src/slideio/drivers/czi/cziscene.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_cziscene_HPP
-#define OPENCV_slideio_cziscene_HPP
+#pragma once
 #include "slideio/drivers/czi/czi_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
 #include "slideio/core/tools/tilecomposer.hpp"
@@ -156,6 +155,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/czi/czislide.hpp
+++ b/src/slideio/drivers/czi/czislide.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_czislide_HPP
-#define OPENCV_slideio_czislide_HPP
+#pragma once
 #include "slideio/drivers/czi/czi_api_def.hpp"
 #include "slideio/core/cvslide.hpp"
 #include "slideio/drivers/czi/cziscene.hpp"
@@ -107,6 +106,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/czi/czistructs.hpp
+++ b/src/slideio/drivers/czi/czistructs.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_czistructs_HPP
-#define OPENCV_slideio_czistructs_HPP
+#pragma once
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -143,4 +142,3 @@ namespace slideio
         Gray64 = 13,
     };
 }
-#endif

--- a/src/slideio/drivers/czi/czisubblock.hpp
+++ b/src/slideio/drivers/czi/czisubblock.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_czisubblock_HPP
-#define OPENCV_slideio_czisubblock_HPP
+#pragma once
 
 #include "slideio/drivers/czi/czi_api_def.hpp"
 #include "slideio/drivers/czi/czistructs.hpp"
@@ -139,6 +138,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/czi/czithumbnail.hpp
+++ b/src/slideio/drivers/czi/czithumbnail.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_czithumbnail_HPP
-#define OPENCV_slideio_czithumbnail_HPP
+#pragma once
 
 
 #include "slideio/drivers/czi/czi_api_def.hpp"
@@ -43,6 +42,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/dcm/dcmfile.hpp
+++ b/src/slideio/drivers/dcm/dcmfile.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_dcmfile_HPP
-#define OPENCV_slideio_dcmfile_HPP
+#pragma once
 
 #include "slideio/drivers/dcm/dcm_api_def.hpp"
 #include "slideio/base/slideio_enums.hpp"
@@ -192,6 +191,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/dcm/dcmimagedriver.hpp
+++ b/src/slideio/drivers/dcm/dcmimagedriver.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_dcmimagedriver_HPP
-#define OPENCV_slideio_dcmimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/dcm/dcm_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -33,6 +32,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/dcm/dcmscene.hpp
+++ b/src/slideio/drivers/dcm/dcmscene.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_dcmscene_HPP
-#define OPENCV_slideio_dcmscene_HPP
+#pragma once
 
 #include <map>
 
@@ -76,6 +75,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/dcm/dcmslide.hpp
+++ b/src/slideio/drivers/dcm/dcmslide.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_dcmslide_HPP
-#define OPENCV_slideio_dcmslide_HPP
+#pragma once
 
 #include "slideio/drivers/dcm/dcm_api_def.hpp"
 #include "slideio/core/cvslide.hpp"
@@ -44,6 +43,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/gdal/gdalimagedriver.hpp
+++ b/src/slideio/drivers/gdal/gdalimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_gdalimagedriver_HPP
-#define OPENCV_slideio_gdalimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/gdal/gdal_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -21,5 +20,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-
-#endif

--- a/src/slideio/drivers/gdal/gdalscene.hpp
+++ b/src/slideio/drivers/gdal/gdalscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_gdalscene_HPP
-#define OPENCV_slideio_gdalscene_HPP
+#pragma once
 
 #include "slideio/drivers/gdal/gdal_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -48,7 +47,5 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif
 

--- a/src/slideio/drivers/gdal/gdalslide.hpp
+++ b/src/slideio/drivers/gdal/gdalslide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_gdalslide_HPP
-#define OPENCV_slideio_gdalslide_HPP
+#pragma once
 
 #include "slideio/drivers/gdal/gdal_api_def.hpp"
 #include "slideio/core/cvslide.hpp"
@@ -40,6 +39,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/ndpi/ndpifile.hpp
+++ b/src/slideio/drivers/ndpi/ndpifile.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpifile_HPP
-#define OPENCV_slideio_ndpifile_HPP
+#pragma once
 
 
 #if defined(_MSC_VER)
@@ -51,6 +50,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/ndpi/ndpiimagedriver.hpp
+++ b/src/slideio/drivers/ndpi/ndpiimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpiimagedriver_HPP
-#define OPENCV_slideio_ndpiimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/ndpi/ndpi_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -19,4 +18,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-#endif

--- a/src/slideio/drivers/ndpi/ndpiscene.hpp
+++ b/src/slideio/drivers/ndpi/ndpiscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpiscene_HPP
-#define OPENCV_slideio_ndpiscene_HPP
+#pragma once
 
 #include "ndpitifftools.hpp"
 #include "slideio/drivers/ndpi/ndpi_api_def.hpp"
@@ -70,6 +69,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/ndpi/ndpislide.hpp
+++ b/src/slideio/drivers/ndpi/ndpislide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpislide_HPP
-#define OPENCV_slideio_ndpislide_HPP
+#pragma once
 
 #include "slideio/drivers/ndpi/ndpi_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -50,6 +49,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/ndpi/ndpitiffmessagehandler.hpp
+++ b/src/slideio/drivers/ndpi/ndpitiffmessagehandler.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpimessagehandler_HPP
-#define OPENCV_slideio_ndpimessagehandler_HPP
+#pragma once
 #include <tiffio.h>
 
 namespace slideio {
@@ -17,5 +16,3 @@ namespace slideio {
         void* m_oldErrorHandler;
     };
 }
-
-#endif

--- a/src/slideio/drivers/ndpi/ndpitifftools.hpp
+++ b/src/slideio/drivers/ndpi/ndpitifftools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_ndpitifftools_HPP
-#define OPENCV_slideio_ndpitifftools_HPP
+#pragma once
 
 
 #include "slideio/drivers/ndpi/ndpi_api_def.hpp"
@@ -157,6 +156,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/ome-tiff/otslide.hpp
+++ b/src/slideio/drivers/ome-tiff/otslide.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 #include "slideio/drivers/ome-tiff/ot_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
 #include "slideio/core/cvslide.hpp"

--- a/src/slideio/drivers/pke/pkeslide.hpp
+++ b/src/slideio/drivers/pke/pkeslide.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 #include "slideio/drivers/pke/pke_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
 #include "slideio/core/cvslide.hpp"

--- a/src/slideio/drivers/scn/scnimagedriver.hpp
+++ b/src/slideio/drivers/scn/scnimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_scnimagedriver_HPP
-#define OPENCV_slideio_scnimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/scn/scn_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -19,4 +18,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-#endif

--- a/src/slideio/drivers/scn/scnscene.hpp
+++ b/src/slideio/drivers/scn/scnscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_scnscene_HPP
-#define OPENCV_slideio_scnscene_HPP
+#pragma once
 
 #include "slideio/drivers/scn/scn_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -114,6 +113,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/scn/scnslide.hpp
+++ b/src/slideio/drivers/scn/scnslide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_scnslide_HPP
-#define OPENCV_slideio_scnslide_HPP
+#pragma once
 
 #include "scnscene.hpp"
 #include "slideio/drivers/scn/scn_api_def.hpp"
@@ -40,6 +39,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/svs/svsimagedriver.hpp
+++ b/src/slideio/drivers/svs/svsimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svsimagedriver_HPP
-#define OPENCV_slideio_svsimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svs_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -19,4 +18,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-#endif

--- a/src/slideio/drivers/svs/svsscene.hpp
+++ b/src/slideio/drivers/svs/svsscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svsscene_HPP
-#define OPENCV_slideio_svsscene_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svs_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -81,6 +80,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/svs/svsslide.hpp
+++ b/src/slideio/drivers/svs/svsslide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svsslide_HPP
-#define OPENCV_slideio_svsslide_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svs_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -49,6 +48,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/svs/svssmallscene.hpp
+++ b/src/slideio/drivers/svs/svssmallscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svssmallscene_HPP
-#define OPENCV_slideio_svssmallscene_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svs_api_def.hpp"
 #include "slideio/drivers/svs/svsscene.hpp"
@@ -35,6 +34,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/svs/svstiledscene.hpp
+++ b/src/slideio/drivers/svs/svstiledscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svstiled_HPP
-#define OPENCV_slideio_svstiled_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svsscene.hpp"
 #include "slideio/imagetools/tifftools.hpp"
@@ -46,6 +45,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/svs/svstools.hpp
+++ b/src/slideio/drivers/svs/svstools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_svstools_HPP
-#define OPENCV_slideio_svstools_HPP
+#pragma once
 
 #include "slideio/drivers/svs/svs_api_def.hpp"
 #include "slideio/imagetools/tifftools.hpp"
@@ -27,5 +26,3 @@ namespace slideio
         static nlohmann::json tiffDirectoryToJson(const TiffDirectory& dir);
     };
 }
-
-#endif

--- a/src/slideio/drivers/vsi/vsiimagedriver.hpp
+++ b/src/slideio/drivers/vsi/vsiimagedriver.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_vsiimagedriver_HPP
-#define OPENCV_slideio_vsiimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/vsi/vsi_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -19,4 +18,3 @@ namespace slideio
         std::string getFileSpecs() const override;
     };
 }
-#endif

--- a/src/slideio/drivers/vsi/vsiscene.hpp
+++ b/src/slideio/drivers/vsi/vsiscene.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_vsiscene_hpp
-#define OPENCV_slideio_vsiscene_hpp
+#pragma once
 
 #include "slideio/drivers/vsi/vsi_api_def.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -75,6 +74,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/vsi/vsislide.hpp
+++ b/src/slideio/drivers/vsi/vsislide.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_VSIslide_HPP
-#define OPENCV_slideio_VSIslide_HPP
+#pragma once
 
 #include "etsfile.hpp"
 #include "slideio/core/cvscene.hpp"
@@ -46,6 +45,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/zvi/pole_lib.hpp
+++ b/src/slideio/drivers/zvi/pole_lib.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wswitch"

--- a/src/slideio/drivers/zvi/zviimagedriver.hpp
+++ b/src/slideio/drivers/zvi/zviimagedriver.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zviimagedriver_HPP
-#define OPENCV_slideio_zviimagedriver_HPP
+#pragma once
 
 #include "slideio/drivers/zvi/zvi_api_def.hpp"
 #include "slideio/core/imagedriver.hpp"
@@ -30,6 +29,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/zvi/zviimageitem.hpp
+++ b/src/slideio/drivers/zvi/zviimageitem.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zviimagedriver_imageitem_HPP
-#define OPENCV_slideio_zviimagedriver_imageitem_HPP
+#pragma once
 #include "slideio/drivers/zvi/pole_lib.hpp"
 #include "slideio/drivers/zvi/zvipixelformat.hpp"
 #include "slideio/base/slideio_enums.hpp"
@@ -86,4 +85,3 @@ namespace slideio
         };
 
 }
-#endif

--- a/src/slideio/drivers/zvi/zvipixelformat.hpp
+++ b/src/slideio/drivers/zvi/zvipixelformat.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zvipixelformat_HPP
-#define OPENCV_slideio_zvipixelformat_HPP
+#pragma once
 
 enum class ZVIPixelFormat
 {
@@ -17,5 +16,3 @@ enum class ZVIPixelFormat
     PF_BGR16,
     PF_BGR32
 };
-
-#endif

--- a/src/slideio/drivers/zvi/zviscene.hpp
+++ b/src/slideio/drivers/zvi/zviscene.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zviscene_HPP
-#define OPENCV_slideio_zviscene_HPP
+#pragma once
 
 #include "slideio/core/cvscene.hpp"
 #include "slideio/core/tools/tilecomposer.hpp"
@@ -95,6 +94,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/zvi/zvislide.hpp
+++ b/src/slideio/drivers/zvi/zvislide.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zvislide_HPP
-#define OPENCV_slideio_zvislide_HPP
+#pragma once
 #include "slideio/core/cvslide.hpp"
 #include "slideio/drivers/zvi/zviscene.hpp"
 #include <fstream>
@@ -39,6 +38,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/drivers/zvi/zvitags.hpp
+++ b/src/slideio/drivers/zvi/zvitags.hpp
@@ -2,8 +2,6 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
 #pragma once
-#ifndef OPENCV_slideio_zvitags_HPP
-#define OPENCV_slideio_zvitags_HPP
 
 #include "slideio/drivers/zvi/zvi_api_def.hpp"
 #include <cstdint>
@@ -442,5 +440,3 @@ namespace slideio
     SLIDEIO_ZVI_EXPORTS const char* getZviTagName(int32_t id);
 }
 
-
-#endif

--- a/src/slideio/drivers/zvi/zvitile.hpp
+++ b/src/slideio/drivers/zvi/zvitile.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_zvitile_HPP
-#define OPENCV_slideio_zvitile_HPP
+#pragma once
 #include <opencv2/core.hpp>
 
 namespace ole {
@@ -35,5 +34,3 @@ namespace slideio
         std::vector<const ZVIImageItem*> m_ImageItems;
     };
 }
-
-#endif

--- a/src/slideio/drivers/zvi/zviutils.hpp
+++ b/src/slideio/drivers/zvi/zviutils.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.#pragma once
-#ifndef OPENCV_slideio_zviutils_HPP
-#define OPENCV_slideio_zviutils_HPP
+#pragma once
 
 #include "slideio/drivers/zvi/zvi_api_def.hpp"
 #include "slideio/drivers/zvi/pole_lib.hpp"
@@ -113,6 +112,4 @@ namespace slideio
 }
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/slideio/imagetools/imagetools.hpp
+++ b/src/slideio/imagetools/imagetools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_imagetools_HPP
-#define OPENCV_slideio_imagetools_HPP
+#pragma once
 
 #include <opencv2/core.hpp>
 #include "slideio/imagetools/slideio_imagetools_def.hpp"
@@ -74,5 +73,3 @@ namespace slideio
         }
     };
 }
-
-#endif

--- a/src/slideio/imagetools/jp2kmem.hpp
+++ b/src/slideio/imagetools/jp2kmem.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/src/slideio/imagetools/jpeglib_aux.hpp
+++ b/src/slideio/imagetools/jpeglib_aux.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 #include <opencv2/core/mat.hpp>
 #include <vector>
 #include <stdint.h>
@@ -9,4 +10,3 @@ void jpeglibEncode(const cv::Mat& raster, std::vector<uint8_t>& encodedStream, i
 void jpeglibDecode(const uint8_t* jpg_buffer, size_t jpg_size, cv::OutputArray output);
 void jpeglibWriteAbbreviatedTables(int numChannels, int quality, std::vector<uint8_t>& tablesBlob);
 void jpeglibEncodeAbbreviated(const cv::Mat& raster, std::vector<uint8_t>& encodedStream, int quality);
-

--- a/src/slideio/imagetools/memory_stream.hpp
+++ b/src/slideio/imagetools/memory_stream.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_memory_stream_HPP
-#define OPENCV_slideio_memory_stream_HPP
+#pragma once
 
 #include "openjpeg.h"
 
@@ -17,5 +16,3 @@ namespace slideio
     };
     opj_stream_t* createOPJMemoryStream(OPJStreamUserData* data, size_t size, bool inputStream);
 }
-
-#endif

--- a/src/slideio/imagetools/similaritytools.hpp
+++ b/src/slideio/imagetools/similaritytools.hpp
@@ -1,6 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
+#pragma once
 #pragma
 
 #include <vector>

--- a/src/slideio/imagetools/tiffkeeper.hpp
+++ b/src/slideio/imagetools/tiffkeeper.hpp
@@ -2,8 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
 
-#ifndef OPENCV_slideio_tiffkeeper_HPP
-#define OPENCV_slideio_tiffkeeper_HPP
+#pragma once
 #include <string>
 
 #include "tifftools.hpp"
@@ -64,5 +63,3 @@ namespace slideio
 }
 
 #define TIFFKeeperPtr std::shared_ptr<slideio::TIFFKeeper>
-
-#endif

--- a/src/slideio/imagetools/tifftools.hpp
+++ b/src/slideio/imagetools/tifftools.hpp
@@ -1,8 +1,7 @@
 // This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_tifftools_HPP
-#define OPENCV_slideio_tifftools_HPP
+#pragma once
 
 #include <map>
 
@@ -95,5 +94,3 @@ namespace slideio
         static void writeRawTile(libtiff::TIFF* tiff, int x, int y, const uint8_t* data, int size);
     };
 }
-
-#endif

--- a/src/slideio/slideio/imagedrivermanager.hpp
+++ b/src/slideio/slideio/imagedrivermanager.hpp
@@ -1,8 +1,7 @@
-﻿// This file is part of slideio project.
+// This file is part of slideio project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://slideio.com/license.html.
-#ifndef OPENCV_slideio_imagedrivermanager_HPP
-#define OPENCV_slideio_imagedrivermanager_HPP
+#pragma once
 
 #include "slideio/slideio/slideio_def.hpp"
 #include <map>
@@ -58,6 +57,4 @@ namespace slideio
 
 #if defined(_MSC_VER)
 #pragma warning( pop )
-#endif
-
 #endif

--- a/src/tools/converter/sceneconverter.hpp
+++ b/src/tools/converter/sceneconverter.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <string>
 
 namespace slideio {


### PR DESCRIPTION
Standardized the codebase to use `#pragma once` in header files.
Files under `src/single_tests` are skipped since it contains 3rd party codes.