### PR TITLE
First attempt to fix #70

### DIFF
--- a/src/slideio/drivers/czi/cziscene.cpp
+++ b/src/slideio/drivers/czi/cziscene.cpp
@@ -287,7 +287,7 @@ void CZIScene::init(uint64_t sceneId, SceneParams& sceneParams, const std::strin
     // separate blocks by zoom levels and detect count of channels and channel data type
     for(const auto& block : blocks)
     {
-        double zoom = block.zoom();
+        double zoom = block.levelZoom();
         int zoomLevelIndex = 0;
         auto itIndex = zoomLevelIndices.find(zoom);
         if(itIndex==zoomLevelIndices.end())
@@ -439,7 +439,7 @@ std::vector<uint8_t> CZIScene::decodeData(const CZISubBlock& block, const std::v
         {
             RAISE_RUNTIME_ERROR << "Unexpected shape of czi sub-block. Expected: (" 
                 << blockRect.width << "," << blockRect.height << "). Received:(" 
-                << raster.cols << "," << raster.rows << "). Zoom: " << block.zoom();
+                << raster.cols << "," << raster.rows << "). Zoom: " << block.levelZoom();
         }
         size_t dataSize = raster.total()*raster.elemSize();
         std::vector<uint8_t> decodedData(dataSize);

--- a/src/slideio/drivers/czi/czisubblock.cpp
+++ b/src/slideio/drivers/czi/czisubblock.cpp
@@ -6,6 +6,8 @@
 #include "slideio/drivers/czi/czisubblock.hpp"
 #include "slideio/drivers/czi/cziscene.hpp"
 
+#include <cmath>
+
 
 bool slideio::CZISubBlock::isInBlock(int channel, int z, int t, int r, int s, int i, int b, int h, int v) const
 {
@@ -28,9 +30,21 @@ slideio::CZISubBlock::CZISubBlock() : m_dataType(DataType::DT_Unknown), m_cziPix
                                           m_compression(-1), m_channelIndex(-1), m_zSliceIndex(-1),
                                           m_tFrameIndex(-1), m_illuminationIndex(-1),
                                           m_bAcquisitionIndex(-1), m_rotationIndex(-1), m_sceneIndex(-1),
-                                          m_hPhaseIndex(-1), m_viewIndex(-1), m_mosaicIndex(-1), m_zoom(1.)
+                                          m_hPhaseIndex(-1), m_viewIndex(-1), m_mosaicIndex(-1), m_levelZoom(1.)
 {
     m_rect = { 0, 0, 0, 0 };
+}
+
+double slideio::CZISubBlock::computeLevelZoom(int size, int storedSize)
+{
+    if (size <= 0 || storedSize <= 0) {
+        return 1.;
+    }
+    const double downsample = std::round(static_cast<double>(size) / storedSize);
+    if (downsample >= 1. && std::fabs(size / downsample - storedSize) < 1.) {
+        return 1. / downsample;
+    }
+    return static_cast<double>(storedSize) / size;
 }
 
 int64_t slideio::CZISubBlock::computeDataOffset(int channel, int z, int t, int r, int s, int i, int b, int h,
@@ -121,7 +135,7 @@ void slideio::CZISubBlock::setupBlock(const SubBlockHeader& subblockHeader, std:
         {
             m_rect.x = dimEntry.start;
             m_rect.width = dimEntry.storedSize;
-            m_zoom = static_cast<double>(dimEntry.storedSize) / static_cast<double>(dimEntry.size);
+            m_levelZoom = computeLevelZoom(dimEntry.size, dimEntry.storedSize);
         }
         else if (dimEntry.dimension[0] == 'Y')
         {

--- a/src/slideio/drivers/czi/czisubblock.hpp
+++ b/src/slideio/drivers/czi/czisubblock.hpp
@@ -49,7 +49,8 @@ namespace slideio
         int firstMosaic() const { return firstDimensionIndex(m_mosaicIndex); }
         int lastMosaic() const { return lastDimensionIndex(m_mosaicIndex); }
         bool isMosaic() const { return m_mosaicIndex > 0; }
-        double zoom() const { return m_zoom; }
+        // Zoom of the pyramid level the sub-block belongs to, derived from the X dimension.
+        double levelZoom() const { return m_levelZoom; }
         const cv::Rect& rect() const { return m_rect; }
         int cziPixelType() const { return m_cziPixelType; }
         int64_t computeDataOffset(int channel, int z, int t, int r, int s, int i, int b, int h, int v) const;
@@ -62,6 +63,15 @@ namespace slideio
         uint64_t dataSize() const {return m_dataSize;}
         Compression compression() const {return static_cast<Compression>(m_compression);}
         const std::vector<Dimension>& dimensions() const {return m_dimensions;}
+        // A sub-block does not name its pyramid level: the level is implied by the ratio of the
+        // stored extent to the logical extent. The writer computes storedSize by rounding
+        // size/downsample (ZEN rounds up, some writers round down), so sub-blocks of one level
+        // share the same raw ratio only if their logical extents are all divisible by the
+        // downsample factor. Snap the ratio to the nominal downsample factor of the level - within
+        // one pixel of storedSize - to make the level independent of that rounding. A ratio that no
+        // integer factor explains - an arbitrarily scaled auxiliary image, for instance - is kept
+        // as it is.
+        static double computeLevelZoom(int size, int storedSize);
         static std::string blockHeaderString()
         {
             std::string header= "Scene0\tSceneN\tZoom\tX\tY\tWidth\tHeight\t"
@@ -72,7 +82,7 @@ namespace slideio
         friend std::ostream &operator<<(std::ostream &output, const CZISubBlock &subBlock) {
             output << subBlock.firstScene() << "\t";
             output << subBlock.lastScene() << "\t";
-            output << subBlock.m_zoom << "\t";
+            output << subBlock.m_levelZoom << "\t";
             output << subBlock.m_rect.x << "\t";
             output << subBlock.m_rect.y << "\t";
             output << subBlock.m_rect.width << "\t";
@@ -130,7 +140,7 @@ namespace slideio
         int m_hPhaseIndex;
         int m_viewIndex;
         int m_mosaicIndex;
-        double m_zoom;
+        double m_levelZoom;
         std::vector<Dimension> m_dimensions;
     };
     typedef std::vector<CZISubBlock> CZISubBlocks;

--- a/src/tests/main/test_czi_driver.cpp
+++ b/src/tests/main/test_czi_driver.cpp
@@ -5,6 +5,7 @@
 #include "slideio/slideio/imagedrivermanager.hpp"
 #include "slideio/drivers/czi/cziimagedriver.hpp"
 #include "slideio/drivers/czi/czislide.hpp"
+#include "slideio/drivers/czi/czisubblock.hpp"
 #include "tests/testlib/testtools.hpp"
 #include "slideio/core/tools/tools.hpp"
 #include "slideio/slideio/scene.hpp"
@@ -31,6 +32,30 @@ TEST(CZIImageDriver, canOpenFile)
     slideio::CZIImageDriver driver;
     EXPECT_TRUE(driver.canOpenFile("c:\\abbb\\a.czi"));
     EXPECT_FALSE(driver.canOpenFile("c:\\abbb\\a.czi.tmp"));
+}
+
+TEST(CZIImageDriver, computeLevelZoom)
+{
+    const double epsilon = 1.e-9;
+    // sub-blocks of one pyramid level are assigned the zoom of the level, whether their
+    // logical extent is divisible by the downsample factor or not
+    EXPECT_NEAR(1., slideio::CZISubBlock::computeLevelZoom(1024, 1024), epsilon);
+    EXPECT_NEAR(0.5, slideio::CZISubBlock::computeLevelZoom(1024, 512), epsilon);
+    EXPECT_NEAR(0.5, slideio::CZISubBlock::computeLevelZoom(1025, 513), epsilon); // rounded up
+    EXPECT_NEAR(0.5, slideio::CZISubBlock::computeLevelZoom(1025, 512), epsilon); // rounded down
+    // ratios taken from affected Zeiss slides; 1213/304 also guards against the size/downsample
+    // division degrading to integer division, which would reject the nominal factor
+    EXPECT_NEAR(0.25, slideio::CZISubBlock::computeLevelZoom(1213, 304), epsilon);
+    EXPECT_NEAR(0.125, slideio::CZISubBlock::computeLevelZoom(6932, 867), epsilon);
+    EXPECT_NEAR(0.0625, slideio::CZISubBlock::computeLevelZoom(15124, 946), epsilon);
+    EXPECT_NEAR(1. / 3., slideio::CZISubBlock::computeLevelZoom(2049, 683), epsilon);
+    EXPECT_NEAR(1. / 3., slideio::CZISubBlock::computeLevelZoom(2050, 683), epsilon);
+    // scaling that no integer downsample factor explains is kept as it is
+    EXPECT_NEAR(0.137, slideio::CZISubBlock::computeLevelZoom(1000, 137), epsilon);
+    EXPECT_NEAR(0.6, slideio::CZISubBlock::computeLevelZoom(1000, 600), epsilon);
+    EXPECT_NEAR(1.5, slideio::CZISubBlock::computeLevelZoom(100, 150), epsilon);
+    EXPECT_NEAR(1., slideio::CZISubBlock::computeLevelZoom(0, 10), epsilon);
+    EXPECT_NEAR(1., slideio::CZISubBlock::computeLevelZoom(1000, 0), epsilon);
 }
 
 TEST(CZIImageDriver, openFile)


### PR DESCRIPTION
CZI: pyramid level is split into two zoom levels when subblock size/storedSize ratios differ, causing read_block() to silently return a partially blank image:
https://github.com/Booritas/slideio/issues/70